### PR TITLE
feat: redesign monitoring register sale flow

### DIFF
--- a/app/src/main/java/com/uitopic/restockmobile/features/monitoring/presentation/screens/RegisterSaleScreen.kt
+++ b/app/src/main/java/com/uitopic/restockmobile/features/monitoring/presentation/screens/RegisterSaleScreen.kt
@@ -1,11 +1,13 @@
 package com.uitopic.restockmobile.features.monitoring.presentation.screens
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,212 +15,231 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Menu
+import androidx.compose.material.icons.outlined.Remove
 import androidx.compose.material.icons.outlined.Restaurant
-import androidx.compose.material.icons.outlined.Schedule
-import androidx.compose.material.icons.rounded.Remove
-import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextButtonDefaults
+import androidx.compose.material3.menuAnchor
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardOptions
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import com.uitopic.restockmobile.ui.theme.RestockmobileTheme
 import java.text.NumberFormat
 import java.util.Locale
 
-private val currencyFormatter = NumberFormat.getCurrencyInstance(Locale.US)
+private enum class RegisterSaleStep {
+    Intro,
+    Dishes,
+    Supplies,
+    Success
+}
 
-private data class SaleDateOption(
-    val label: String,
-    val date: String // antes LocalDate, ahora String para evitar requerir API 26
+private data class DishOption(
+    val id: Int,
+    val name: String,
+    val unitPrice: Double
 )
 
-private data class SaleTimeOption(
-    val label: String
+private data class DishSelection(
+    val option: DishOption,
+    val quantity: Int,
+    val isSelected: Boolean
 )
 
 private data class SupplyOption(
     val id: Int,
     val name: String,
-    val description: String,
-    val unitPrice: Double
+    val suggestedQuantity: String
 )
 
 private data class SupplySelection(
     val option: SupplyOption,
-    val quantity: Int
+    val quantity: String,
+    val isSelected: Boolean
 )
 
-@OptIn(ExperimentalMaterial3Api::class)
+private val peruvianCurrencyFormatter = NumberFormat.getCurrencyInstance(Locale("es", "PE"))
+
 @Composable
 fun RegisterSaleScreen(
     onBack: () -> Unit
 ) {
-    val dateOptions = remember {
+    val dishOptions = remember {
         listOf(
-            SaleDateOption("Mar 03, 2023", "2023-03-03"),
-            SaleDateOption("Mar 04, 2023", "2023-03-04"),
-            SaleDateOption("Mar 05, 2023", "2023-03-05")
-        )
-    }
-    val timeOptions = remember {
-        listOf(
-            SaleTimeOption("12:30 pm"),
-            SaleTimeOption("01:15 pm"),
-            SaleTimeOption("07:45 pm")
+            DishOption(1, "Lomo Saltado", 20.50),
+            DishOption(2, "Arroz con Pollo", 15.50),
+            DishOption(3, "Sopa dieta", 12.80)
         )
     }
     val supplyOptions = remember {
         listOf(
-            SupplyOption(1, "Lemon", "Fresh whole lemons", 2.50),
-            SupplyOption(2, "Feta cheese", "Crumbled, 1 lb bag", 4.75),
-            SupplyOption(3, "Olive oil", "Extra virgin 500 ml", 7.80),
-            SupplyOption(4, "Pasta", "Rigatoni, 1 lb box", 3.60),
-            SupplyOption(5, "Flour", "00 flour, 1 kg", 2.90)
+            SupplyOption(1, "Huevo", "1"),
+            SupplyOption(2, "Arroz", "250 g"),
+            SupplyOption(3, "Inka cola personal", "1")
         )
     }
 
-    var isRegistering by remember { mutableStateOf(false) }
-    var selectedDate by remember { mutableStateOf<SaleDateOption?>(null) }
-    var selectedTime by remember { mutableStateOf<SaleTimeOption?>(null) }
-    var selections by remember { mutableStateOf<Map<Int, SupplySelection>>(emptyMap()) }
-    var showSuccessDialog by remember { mutableStateOf(false) }
-    var showCreationHint by remember { mutableStateOf(true) }
+    var step by remember { mutableStateOf(RegisterSaleStep.Intro) }
+    var dishSelections by remember { mutableStateOf<List<DishSelection>>(emptyList()) }
+    var supplySelections by remember { mutableStateOf<List<SupplySelection>>(emptyList()) }
 
-    LaunchedEffect(isRegistering) {
-        if (isRegistering) {
-            showCreationHint = false
-        }
+    fun resetSale() {
+        step = RegisterSaleStep.Intro
+        dishSelections = emptyList()
+        supplySelections = emptyList()
     }
 
     Scaffold(
-        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        containerColor = MaterialTheme.colorScheme.background,
         topBar = {
-            RegisterSaleHeader(
-                onMenuClick = onBack
-            )
+            MonitoringTopBar(onMenuClick = onBack)
         }
     ) { padding ->
-        LazyColumn(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
                 .padding(horizontal = 20.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            if (!isRegistering) {
-                item {
-                    EmptySaleState(
-                        onCreateSale = { isRegistering = true },
-                        onClose = onBack
+            when (step) {
+                RegisterSaleStep.Intro -> {
+                    RegisterSaleIntroCard(
+                        onCreateSale = { step = RegisterSaleStep.Dishes }
                     )
                 }
-            } else {
-                item {
-                    SaleFormCard(
-                        dateOptions = dateOptions,
-                        timeOptions = timeOptions,
+
+                RegisterSaleStep.Dishes -> {
+                    RegisterSaleDishesCard(
+                        dishOptions = dishOptions,
                         supplyOptions = supplyOptions,
-                        selectedDate = selectedDate,
-                        selectedTime = selectedTime,
-                        selections = selections,
-                        showCreationHint = showCreationHint,
-                        onSelectDate = { selectedDate = it },
-                        onSelectTime = { selectedTime = it },
-                        onChangeQuantity = { option, quantity ->
-                            selections = if (quantity <= 0) {
-                                selections - option.id
-                            } else {
-                                selections + (option.id to SupplySelection(option, quantity))
+                        selections = dishSelections,
+                        onAddDish = { option ->
+                            if (dishSelections.none { it.option.id == option.id }) {
+                                dishSelections = dishSelections + DishSelection(option, quantity = 1, isSelected = true)
+                            }
+                        },
+                        onAddSupply = { option ->
+                            if (supplySelections.none { it.option.id == option.id }) {
+                                supplySelections = supplySelections + SupplySelection(
+                                    option = option,
+                                    quantity = option.suggestedQuantity,
+                                    isSelected = true
+                                )
+                            }
+                        },
+                        onToggleSelection = { selection, isSelected ->
+                            dishSelections = dishSelections.map {
+                                if (it.option.id == selection.option.id) it.copy(isSelected = isSelected) else it
+                            }
+                        },
+                        onChangeQuantity = { selection, quantity ->
+                            dishSelections = dishSelections.map {
+                                if (it.option.id == selection.option.id) it.copy(quantity = quantity.coerceAtLeast(1)) else it
+                            }
+                        },
+                        onRemoveSelection = { selection ->
+                            dishSelections = dishSelections.filterNot { it.option.id == selection.option.id }
+                        },
+                        onCancel = { resetSale() },
+                        onNext = {
+                            if (dishSelections.isNotEmpty()) {
+                                step = RegisterSaleStep.Supplies
                             }
                         }
                     )
                 }
 
-                item {
-                    SaleActionButtons(
-                        isAddEnabled = selectedDate != null && selectedTime != null && selections.isNotEmpty(),
-                        onCancel = {
-                            isRegistering = false
-                            selectedDate = null
-                            selectedTime = null
-                            selections = emptyMap()
+                RegisterSaleStep.Supplies -> {
+                    RegisterSaleSuppliesCard(
+                        supplyOptions = supplyOptions,
+                        selections = supplySelections,
+                        onAddSupply = { option ->
+                            if (supplySelections.none { it.option.id == option.id }) {
+                                supplySelections = supplySelections + SupplySelection(
+                                    option = option,
+                                    quantity = option.suggestedQuantity,
+                                    isSelected = true
+                                )
+                            }
                         },
-                        onReset = {
-                            selectedDate = null
-                            selectedTime = null
-                            selections = emptyMap()
+                        onToggleSelection = { selection, isSelected ->
+                            supplySelections = supplySelections.map {
+                                if (it.option.id == selection.option.id) it.copy(isSelected = isSelected) else it
+                            }
                         },
-                        onAdd = { showSuccessDialog = true }
+                        onChangeQuantity = { selection, quantity ->
+                            supplySelections = supplySelections.map {
+                                if (it.option.id == selection.option.id) it.copy(quantity = quantity) else it
+                            }
+                        },
+                        onRemoveSelection = { selection ->
+                            supplySelections = supplySelections.filterNot { it.option.id == selection.option.id }
+                        },
+                        onBack = { step = RegisterSaleStep.Dishes },
+                        onCancel = { resetSale() },
+                        onSave = { step = RegisterSaleStep.Success }
+                    )
+                }
+
+                RegisterSaleStep.Success -> {
+                    RegisterSaleSuccessCard(
+                        selectedDishes = dishSelections.filter { it.isSelected },
+                        selectedSupplies = supplySelections.filter { it.isSelected },
+                        onClose = { resetSale() }
                     )
                 }
             }
         }
     }
-
-    if (showSuccessDialog) {
-        RegisterSaleSuccessDialog(
-            selectedDate = selectedDate,
-            selectedTime = selectedTime,
-            selections = selections.values.toList(),
-            onDismiss = {
-                showSuccessDialog = false
-                isRegistering = false
-                selectedDate = null
-                selectedTime = null
-                selections = emptyMap()
-            }
-        )
-    }
 }
-
 @Composable
-private fun RegisterSaleHeader(
+private fun MonitoringTopBar(
     onMenuClick: () -> Unit
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surfaceVariant,
+        color = MaterialTheme.colorScheme.background,
         shadowElevation = 0.dp
     ) {
         Column(
@@ -235,28 +256,11 @@ private fun RegisterSaleHeader(
                 PlaceholderBrand(modifier = Modifier.weight(1f))
                 IconButton(onClick = onMenuClick) {
                     Icon(
-                        imageVector = Icons.Default.Menu,
+                        imageVector = Icons.Outlined.Menu,
                         contentDescription = "Menu"
                     )
                 }
             }
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                text = "Register sale",
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = "Complete the fields to register a sale. Choose the dates and additional ingredients needed for the service.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
         }
     }
 }
@@ -267,8 +271,7 @@ private fun PlaceholderAvatar() {
         modifier = Modifier.size(48.dp),
         color = Color.White,
         shape = CircleShape,
-        tonalElevation = 1.dp,
-        shadowElevation = 2.dp
+        tonalElevation = 1.dp
     ) {}
 }
 
@@ -292,226 +295,344 @@ private fun PlaceholderBrand(modifier: Modifier = Modifier) {
         ) {}
     }
 }
+@Composable
+private fun RegisterSaleIntroCard(
+    onCreateSale: () -> Unit
+) {
+    RegisterSaleCard(
+        title = "Register sale",
+        subtitle = "You currently have no recorded sales. Enter your sales here to keep your inventory up to date.",
+        topRightContent = {
+            ActionButton(
+                text = "NEW",
+                icon = Icons.Outlined.Add,
+                containerColor = Color(0xFF2E7D32),
+                onClick = onCreateSale,
+                modifier = Modifier.height(40.dp)
+            )
+        }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 32.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Restaurant,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(80.dp)
+            )
+        }
+    }
+}
 
 @Composable
-private fun EmptySaleState(
-    onCreateSale: () -> Unit,
-    onClose: () -> Unit
+private fun RegisterSaleDishesCard(
+    dishOptions: List<DishOption>,
+    supplyOptions: List<SupplyOption>,
+    selections: List<DishSelection>,
+    onAddDish: (DishOption) -> Unit,
+    onAddSupply: (SupplyOption) -> Unit,
+    onToggleSelection: (DishSelection, Boolean) -> Unit,
+    onChangeQuantity: (DishSelection, Int) -> Unit,
+    onRemoveSelection: (DishSelection) -> Unit,
+    onCancel: () -> Unit,
+    onNext: () -> Unit
 ) {
-    CardContainer {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Surface(
-                modifier = Modifier
-                    .size(120.dp)
-                    .clip(MaterialTheme.shapes.large),
-                tonalElevation = 2.dp,
-                shape = MaterialTheme.shapes.large,
-                color = MaterialTheme.colorScheme.surfaceVariant
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = Icons.Outlined.Restaurant,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(56.dp)
-                    )
+    var selectedDish by remember { mutableStateOf<String?>(null) }
+    var selectedSupply by remember { mutableStateOf<String?>(null) }
+
+    RegisterSaleCard(
+        title = "Register sale",
+        subtitle = "Complete the details of a new sale to access the inventory update option."
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+            SelectorField(
+                label = "Dishes",
+                placeholder = "Select a dish from your recipe list",
+                options = dishOptions.map { it.name },
+                selectedOption = selectedDish,
+                onOptionSelected = { name ->
+                    selectedDish = name
+                    dishOptions.firstOrNull { it.name == name }?.let(onAddDish)
                 }
+            )
+
+            SelectorField(
+                label = "Additional supplies",
+                placeholder = "Select a supply from your inventory",
+                options = supplyOptions.map { it.name },
+                selectedOption = selectedSupply,
+                onOptionSelected = { name ->
+                    selectedSupply = name
+                    supplyOptions.firstOrNull { it.name == name }?.let(onAddSupply)
+                }
+            )
+
+            if (selections.isEmpty()) {
+                Text(
+                    text = "Select the dishes and additional ingredients from the order to view the full sale.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            } else {
+                DishesTable(
+                    selections = selections,
+                    onToggleSelection = onToggleSelection,
+                    onChangeQuantity = onChangeQuantity,
+                    onRemoveSelection = onRemoveSelection
+                )
             }
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                text = "You have no registered sales",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                textAlign = TextAlign.Center
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = "Once you register a sale, you will be able to review its information and the additional ingredients required for preparation.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                OutlinedButton(
-                    onClick = onClose,
+                ActionButton(
+                    text = "CANCEL",
+                    icon = Icons.Filled.Close,
+                    containerColor = Color(0xFFD84343),
+                    onClick = onCancel,
                     modifier = Modifier.weight(1f)
-                ) {
-                    Text("Close")
-                }
-                Button(
-                    onClick = onCreateSale,
+                )
+                ActionButton(
+                    text = "NEXT",
+                    icon = Icons.Filled.KeyboardArrowRight,
+                    containerColor = Color(0xFFFFA000),
+                    onClick = onNext,
+                    enabled = selections.isNotEmpty(),
                     modifier = Modifier.weight(1f)
-                ) {
-                    Icon(Icons.Outlined.Add, contentDescription = null)
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text("Create sale")
-                }
+                )
             }
         }
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SaleFormCard(
-    dateOptions: List<SaleDateOption>,
-    timeOptions: List<SaleTimeOption>,
+private fun RegisterSaleSuppliesCard(
     supplyOptions: List<SupplyOption>,
-    selectedDate: SaleDateOption?,
-    selectedTime: SaleTimeOption?,
-    selections: Map<Int, SupplySelection>,
-    showCreationHint: Boolean,
-    onSelectDate: (SaleDateOption) -> Unit,
-    onSelectTime: (SaleTimeOption) -> Unit,
-    onChangeQuantity: (SupplyOption, Int) -> Unit
+    selections: List<SupplySelection>,
+    onAddSupply: (SupplyOption) -> Unit,
+    onToggleSelection: (SupplySelection, Boolean) -> Unit,
+    onChangeQuantity: (SupplySelection, String) -> Unit,
+    onRemoveSelection: (SupplySelection) -> Unit,
+    onBack: () -> Unit,
+    onCancel: () -> Unit,
+    onSave: () -> Unit
 ) {
-    CardContainer {
+    var selectedSupply by remember { mutableStateOf<String?>(null) }
+
+    RegisterSaleCard(
+        title = "Register sale",
+        subtitle = "Complete the details of a new sale to access the inventory update option."
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+            SelectorField(
+                label = "Additional supplies",
+                placeholder = "Select an input from your inventory",
+                options = supplyOptions.map { it.name },
+                selectedOption = selectedSupply,
+                onOptionSelected = { name ->
+                    selectedSupply = name
+                    supplyOptions.firstOrNull { it.name == name }?.let(onAddSupply)
+                }
+            )
+
+            if (selections.isEmpty()) {
+                Text(
+                    text = "No additional supplies were added for this sale.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            } else {
+                SuppliesTable(
+                    selections = selections,
+                    onToggleSelection = onToggleSelection,
+                    onChangeQuantity = onChangeQuantity,
+                    onRemoveSelection = onRemoveSelection
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                ActionButton(
+                    text = "BACK",
+                    icon = Icons.Filled.KeyboardArrowLeft,
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                    onClick = onBack,
+                    modifier = Modifier.weight(1f)
+                )
+                ActionButton(
+                    text = "CANCEL",
+                    icon = Icons.Filled.Close,
+                    containerColor = Color(0xFFD84343),
+                    onClick = onCancel,
+                    modifier = Modifier.weight(1f)
+                )
+                ActionButton(
+                    text = "SAVE",
+                    icon = Icons.Filled.Check,
+                    containerColor = Color(0xFF2E7D32),
+                    onClick = onSave,
+                    enabled = selections.isNotEmpty(),
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+@Composable
+private fun RegisterSaleSuccessCard(
+    selectedDishes: List<DishSelection>,
+    selectedSupplies: List<SupplySelection>,
+    onClose: () -> Unit
+) {
+    RegisterSaleCard(
+        title = "Sale successfully registered",
+        subtitle = "The sale and its additional supplies have been saved correctly."
+    ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(
-                    text = "Dates",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
-                Text(
-                    text = "Choose the date and time for this sale.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-
-                DropdownSelector(
-                    label = "Sale date",
-                    value = selectedDate?.label,
-                    placeholder = "Select date",
-                    icon = Icons.Outlined.CalendarMonth,
-                    options = dateOptions.map { it.label },
-                    onOptionSelected = { label ->
-                        dateOptions.firstOrNull { it.label == label }?.let(onSelectDate)
-                    }
-                )
-
-                DropdownSelector(
-                    label = "Sale time",
-                    value = selectedTime?.label,
-                    placeholder = "Select time",
-                    icon = Icons.Outlined.Schedule,
-                    options = timeOptions.map { it.label },
-                    onOptionSelected = { label ->
-                        timeOptions.firstOrNull { it.label == label }?.let(onSelectTime)
-                    }
-                )
-
-                if (selectedDate != null || selectedTime != null) {
-                    SummaryCard(
-                        title = "Selected dates",
-                        rows = listOfNotNull(
-                            selectedDate?.let { "Sale date" to it.label },
-                            selectedTime?.let { "Sale time" to it.label }
-                        )
+            Surface(
+                modifier = Modifier.size(96.dp),
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(48.dp)
                     )
                 }
             }
 
-            Divider()
-
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text(
-                    text = "Additional supplies",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
-                Text(
-                    text = "Select the dishes and additional ingredients required for this sale.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    supplyOptions.forEach { option ->
-                        SupplyRow(
-                            option = option,
-                            quantity = selections[option.id]?.quantity ?: 0,
-                            onChangeQuantity = { quantity -> onChangeQuantity(option, quantity) }
-                        )
-                    }
-                }
-
-                if (selections.isNotEmpty()) {
-                    SummaryCard(
-                        title = "Selected additional supplies",
-                        rows = selections.values.map {
-                            it.option.name to "${it.quantity} x ${currencyFormatter.format(it.option.unitPrice)}"
-                        }
-                    )
-
-                    FinancialSummary(
-                        selections = selections.values.toList()
+            SummaryTable(
+                title = "Dishes",
+                headers = listOf("Name", "Unit price", "Quantity"),
+                rows = selectedDishes.map { selection ->
+                    listOf(
+                        selection.option.name,
+                        peruvianCurrencyFormatter.format(selection.option.unitPrice),
+                        selection.quantity.toString()
                     )
                 }
+            )
 
-                if (showCreationHint) {
-                    InfoHint(
-                        text = "Start by selecting a date and the ingredients you need."
+            SummaryTable(
+                title = "Additional supplies",
+                headers = listOf("Nombre", "Cantidad"),
+                rows = selectedSupplies.map { selection ->
+                    listOf(
+                        selection.option.name,
+                        selection.quantity
                     )
+                }
+            )
+
+            ActionButton(
+                text = "CLOSE",
+                icon = Icons.Filled.Close,
+                containerColor = Color(0xFFD84343),
+                onClick = onClose,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun RegisterSaleCard(
+    title: String,
+    subtitle: String,
+    topRightContent: (@Composable (() -> Unit))? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(32.dp),
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 6.dp,
+        shadowElevation = 6.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 28.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                if (topRightContent != null) {
+                    Spacer(modifier = Modifier.width(12.dp))
+                    topRightContent()
                 }
             }
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            content()
         }
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DropdownSelector(
+private fun SelectorField(
     label: String,
-    value: String?,
     placeholder: String,
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
     options: List<String>,
+    selectedOption: String?,
     onOptionSelected: (String) -> Unit
 ) {
-    var expanded by remember { mutableStateOf(false) }
-
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(
             text = label,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
         )
-        Box {
+        var expanded by remember { mutableStateOf(false) }
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded }
+        ) {
             OutlinedTextField(
-                value = value ?: "",
+                value = selectedOption ?: "",
                 onValueChange = {},
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(Color.Transparent)
-                    .clip(MaterialTheme.shapes.extraSmall)
-                    .clickable { expanded = !expanded },
+                    .menuAnchor(),
                 readOnly = true,
-                label = { Text(placeholder) },
-                trailingIcon = {
-                    Icon(
-                        imageVector = Icons.Filled.ArrowDropDown,
-                        contentDescription = null
-                    )
-                },
-                leadingIcon = {
-                    Icon(imageVector = icon, contentDescription = null)
-                }
+                singleLine = true,
+                placeholder = { Text(placeholder) },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) }
             )
             DropdownMenu(
                 expanded = expanded,
@@ -521,8 +642,8 @@ private fun DropdownSelector(
                     DropdownMenuItem(
                         text = { Text(option) },
                         onClick = {
-                            expanded = false
                             onOptionSelected(option)
+                            expanded = false
                         }
                     )
                 }
@@ -530,426 +651,383 @@ private fun DropdownSelector(
         }
     }
 }
+@Composable
+private fun DishesTable(
+    selections: List<DishSelection>,
+    onToggleSelection: (DishSelection, Boolean) -> Unit,
+    onChangeQuantity: (DishSelection, Int) -> Unit,
+    onRemoveSelection: (DishSelection) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        TableHeader(
+            title = "Selected dishes",
+            selected = selections.count { it.isSelected },
+            total = selections.size
+        )
+
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(24.dp),
+            tonalElevation = 1.dp
+        ) {
+            Column {
+                TableRow(
+                    background = MaterialTheme.colorScheme.surfaceVariant
+                ) {
+                    TableCell(text = "Name", weight = 0.4f, isHeader = true)
+                    TableCell(text = "Unit price", weight = 0.3f, isHeader = true)
+                    TableCell(text = "Quantity", weight = 0.2f, isHeader = true, textAlign = TextAlign.Center)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+
+                selections.forEachIndexed { index, selection ->
+                    TableRow {
+                        TableCell(text = selection.option.name, weight = 0.4f)
+                        TableCell(
+                            text = peruvianCurrencyFormatter.format(selection.option.unitPrice),
+                            weight = 0.3f
+                        )
+                        Box(modifier = Modifier.weight(0.2f), contentAlignment = Alignment.Center) {
+                            QuantitySelector(
+                                quantity = selection.quantity,
+                                onDecrease = { onChangeQuantity(selection, selection.quantity - 1) },
+                                onIncrease = { onChangeQuantity(selection, selection.quantity + 1) }
+                            )
+                        }
+                        Checkbox(
+                            checked = selection.isSelected,
+                            onCheckedChange = { onToggleSelection(selection, it) }
+                        )
+                    }
+
+                    if (index < selections.lastIndex) {
+                        Divider()
+                    }
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            TextButton(
+                onClick = { selections.lastOrNull()?.let(onRemoveSelection) },
+                enabled = selections.isNotEmpty(),
+                colors = TextButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error
+                )
+            ) {
+                Icon(Icons.Outlined.Delete, contentDescription = null)
+                Spacer(modifier = Modifier.width(4.dp))
+                Text("Delete")
+            }
+        }
+    }
+}
 
 @Composable
-private fun SupplyRow(
-    option: SupplyOption,
-    quantity: Int,
-    onChangeQuantity: (Int) -> Unit
+private fun SuppliesTable(
+    selections: List<SupplySelection>,
+    onToggleSelection: (SupplySelection, Boolean) -> Unit,
+    onChangeQuantity: (SupplySelection, String) -> Unit,
+    onRemoveSelection: (SupplySelection) -> Unit
 ) {
-    Column(
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        TableHeader(
+            title = "Selected additional supplies",
+            selected = selections.count { it.isSelected },
+            total = selections.size
+        )
+
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(24.dp),
+            tonalElevation = 1.dp
+        ) {
+            Column {
+                TableRow(
+                    background = MaterialTheme.colorScheme.surfaceVariant
+                ) {
+                    TableCell(text = "Name", weight = 0.5f, isHeader = true)
+                    TableCell(text = "Quantity", weight = 0.3f, isHeader = true)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+
+                selections.forEachIndexed { index, selection ->
+                    TableRow {
+                        TableCell(text = selection.option.name, weight = 0.5f)
+                        Box(modifier = Modifier.weight(0.3f)) {
+                            OutlinedTextField(
+                                value = selection.quantity,
+                                onValueChange = { onChangeQuantity(selection, it) },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                keyboardOptions = KeyboardOptions.Default
+                            )
+                        }
+                        Checkbox(
+                            checked = selection.isSelected,
+                            onCheckedChange = { onToggleSelection(selection, it) }
+                        )
+                    }
+
+                    if (index < selections.lastIndex) {
+                        Divider()
+                    }
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            TextButton(
+                onClick = { selections.lastOrNull()?.let(onRemoveSelection) },
+                enabled = selections.isNotEmpty(),
+                colors = TextButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error
+                )
+            ) {
+                Icon(Icons.Outlined.Delete, contentDescription = null)
+                Spacer(modifier = Modifier.width(4.dp))
+                Text("Delete")
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableHeader(
+    title: String,
+    selected: Int,
+    total: Int
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { }) {
+                Icon(Icons.Filled.KeyboardArrowLeft, contentDescription = null)
+            }
+            Text(
+                text = "$selected of $total",
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium
+            )
+            IconButton(onClick = { }) {
+                Icon(Icons.Filled.KeyboardArrowRight, contentDescription = null)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableRow(
+    background: Color = Color.Transparent,
+    content: @Composable RowScope.() -> Unit
+) {
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(
-                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
-                shape = MaterialTheme.shapes.medium
-            )
-            .padding(16.dp)
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = option.name,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = option.description,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-            Spacer(modifier = Modifier.width(12.dp))
-            QuantityStepper(
-                quantity = quantity,
-                onQuantityDecrease = { onChangeQuantity((quantity - 1).coerceAtLeast(0)) },
-                onQuantityIncrease = { onChangeQuantity(quantity + 1) }
-            )
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Text(
-            text = "Unit price: ${currencyFormatter.format(option.unitPrice)}",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.primary
-        )
-    }
-}
-
-@Composable
-private fun QuantityStepper(
-    quantity: Int,
-    onQuantityDecrease: () -> Unit,
-    onQuantityIncrease: () -> Unit
-) {
-    Row(
+            .background(background)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        IconButton(
-            onClick = onQuantityDecrease,
-            enabled = quantity > 0
-        ) {
-            Icon(imageVector = Icons.Rounded.Remove, contentDescription = "Decrease")
-        }
-        Surface(
-            tonalElevation = 1.dp,
-            shape = MaterialTheme.shapes.small
-        ) {
-            Text(
-                text = quantity.toString(),
-                modifier = Modifier
-                    .widthIn(min = 36.dp)
-                    .padding(vertical = 6.dp),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.titleMedium
+        content = content
+    )
+}
+
+@Composable
+private fun RowScope.TableCell(
+    text: String,
+    weight: Float,
+    isHeader: Boolean = false,
+    textAlign: TextAlign = TextAlign.Start
+) {
+    Text(
+        text = text,
+        modifier = Modifier.weight(weight),
+        style = if (isHeader) MaterialTheme.typography.labelLarge else MaterialTheme.typography.bodyMedium,
+        fontWeight = if (isHeader) FontWeight.SemiBold else FontWeight.Normal,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = textAlign
+    )
+}
+
+@Composable
+private fun QuantitySelector(
+    quantity: Int,
+    onDecrease: () -> Unit,
+    onIncrease: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outline,
+                shape = RoundedCornerShape(12.dp)
             )
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = { if (quantity > 1) onDecrease() }, enabled = quantity > 1) {
+            Icon(Icons.Outlined.Remove, contentDescription = null)
         }
-        IconButton(onClick = onQuantityIncrease) {
-            Icon(imageVector = Icons.Outlined.Add, contentDescription = "Increase")
+        Text(
+            text = quantity.toString(),
+            fontWeight = FontWeight.SemiBold
+        )
+        IconButton(onClick = onIncrease) {
+            Icon(Icons.Outlined.Add, contentDescription = null)
         }
     }
 }
 
 @Composable
-private fun SummaryCard(
+private fun ActionButton(
+    text: String,
+    icon: ImageVector? = null,
+    containerColor: Color,
+    contentColor: Color = Color.White,
+    enabled: Boolean = true,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = containerColor,
+            contentColor = contentColor,
+            disabledContainerColor = containerColor.copy(alpha = 0.4f),
+            disabledContentColor = contentColor.copy(alpha = 0.6f)
+        )
+    ) {
+        if (icon != null) {
+            Icon(icon, contentDescription = null)
+            Spacer(modifier = Modifier.width(6.dp))
+        }
+        Text(text = text, fontWeight = FontWeight.Bold)
+    }
+}
+
+@Composable
+private fun SummaryTable(
     title: String,
-    rows: List<Pair<String, String>>
+    headers: List<String>,
+    rows: List<List<String>>
 ) {
-    OutlinedCard(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(24.dp),
+            tonalElevation = 1.dp
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.SemiBold
-            )
-            rows.forEach { (label, value) ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
+            Column {
+                TableRow(
+                    background = MaterialTheme.colorScheme.surfaceVariant
                 ) {
-                    Text(
-                        text = label,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        text = value,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.Medium
-                    )
+                    headers.forEach { header ->
+                        TableCell(text = header, weight = 1f, isHeader = true)
+                    }
                 }
-            }
-        }
-    }
-}
-
-@Composable
-private fun FinancialSummary(
-    selections: List<SupplySelection>
-) {
-    val subtotal = selections.sumOf { it.option.unitPrice * it.quantity }
-    val taxes = subtotal * 0.08
-    val total = subtotal + taxes
-
-    OutlinedCard(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Text(
-                text = "Sale summary",
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.SemiBold
-            )
-            SummaryRow(label = "Subtotal", value = currencyFormatter.format(subtotal))
-            SummaryRow(label = "Taxes (8%)", value = currencyFormatter.format(taxes))
-            HorizontalDivider() // reemplaza Divider deprecado
-            SummaryRow(
-                label = "Total",
-                value = currencyFormatter.format(total),
-                emphasize = true
-            )
-        }
-    }
-}
-
-@Composable
-private fun SummaryRow(
-    label: String,
-    value: String,
-    emphasize: Boolean = false
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodySmall,
-            color = if (emphasize) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
-            fontWeight = if (emphasize) FontWeight.Bold else FontWeight.Normal
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = if (emphasize) FontWeight.Bold else FontWeight.Medium
-        )
-    }
-}
-
-@Composable
-private fun InfoHint(text: String) {
-    OutlinedCard(
-        modifier = Modifier.fillMaxWidth(),
-        colors = androidx.compose.material3.CardDefaults.outlinedCardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f)
-        )
-    ) {
-        Text(
-            text = text,
-            modifier = Modifier.padding(16.dp),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
-}
-
-@Composable
-private fun SaleActionButtons(
-    isAddEnabled: Boolean,
-    onCancel: () -> Unit,
-    onReset: () -> Unit,
-    onAdd: () -> Unit
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        OutlinedButton(
-            onClick = onCancel,
-            modifier = Modifier.weight(1f)
-        ) {
-            Icon(imageVector = Icons.Default.Close, contentDescription = null)
-            Spacer(modifier = Modifier.width(8.dp))
-            Text("Cancel")
-        }
-        OutlinedButton(
-            onClick = onReset,
-            modifier = Modifier.weight(1f)
-        ) {
-            Text("Reset")
-        }
-        Button(
-            onClick = onAdd,
-            enabled = isAddEnabled,
-            modifier = Modifier.weight(1f)
-        ) {
-            Icon(imageVector = Icons.Outlined.Add, contentDescription = null)
-            Spacer(modifier = Modifier.width(8.dp))
-            Text("Add sale")
-        }
-    }
-}
-
-@Composable
-private fun RegisterSaleSuccessDialog(
-    selectedDate: SaleDateOption?,
-    selectedTime: SaleTimeOption?,
-    selections: List<SupplySelection>,
-    onDismiss: () -> Unit
-) {
-    Dialog(onDismissRequest = onDismiss) {
-        RegisterSaleSuccessContent(
-            selectedDate = selectedDate,
-            selectedTime = selectedTime,
-            selections = selections,
-            onDismiss = onDismiss
-        )
-    }
-}
-
-@Composable
-private fun RegisterSaleSuccessContent(
-    selectedDate: SaleDateOption?,
-    selectedTime: SaleTimeOption?,
-    selections: List<SupplySelection>,
-    onDismiss: () -> Unit
-) {
-    Surface(
-        shape = MaterialTheme.shapes.large,
-        tonalElevation = AlertDialogDefaults.TonalElevation
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Surface(
-                modifier = Modifier.size(88.dp),
-                shape = MaterialTheme.shapes.extraLarge,
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = Icons.Filled.Check,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(44.dp)
-                    )
-                }
-            }
-
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text(
-                    text = "Sale successfully registered",
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                    textAlign = TextAlign.Center
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "The sale and its additional supplies have been saved correctly.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center
-                )
-            }
-
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                SummaryCard(
-                    title = "Dates",
-                    rows = listOfNotNull(
-                        selectedDate?.let { "Sale date" to it.label },
-                        selectedTime?.let { "Sale time" to it.label }
-                    )
-                )
-
-                OutlinedCard(modifier = Modifier.fillMaxWidth()) {
-                    Column(
-                        modifier = Modifier.padding(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
+                if (rows.isEmpty()) {
+                    TableRow {
                         Text(
-                            text = "Additional supplies",
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold
+                            text = "No records available",
+                            modifier = Modifier.fillMaxWidth(),
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                        if (selections.isEmpty()) {
-                            Text(
-                                text = "No additional supplies were added.",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        } else {
-                            selections.forEach { selection ->
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.SpaceBetween
-                                ) {
-                                    Text(
-                                        text = selection.option.name,
-                                        style = MaterialTheme.typography.bodySmall
-                                    )
-                                    Text(
-                                        text = "${selection.quantity} x ${currencyFormatter.format(selection.option.unitPrice)}",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        fontWeight = FontWeight.Medium
-                                    )
-                                }
+                    }
+                } else {
+                    rows.forEachIndexed { index, values ->
+                        TableRow {
+                            values.forEach { value ->
+                                TableCell(text = value, weight = 1f)
                             }
+                        }
+                        if (index < rows.lastIndex) {
+                            HorizontalDivider()
                         }
                     }
                 }
-
-                FinancialSummary(selections)
-            }
-
-            Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
-                Text("Close")
             }
         }
     }
 }
-
+@Preview(showBackground = true)
 @Composable
-private fun CardContainer(
-    modifier: Modifier = Modifier,
-    shape: Shape = MaterialTheme.shapes.large,
-    content: @Composable () -> Unit
-) {
-    Surface(
-        modifier = modifier.fillMaxWidth(),
-        shape = shape,
-        color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 2.dp,
-        shadowElevation = 2.dp
-    ) {
-        Column(modifier = Modifier.padding(24.dp)) {
-            content()
-        }
+private fun RegisterSaleIntroPreview() {
+    RestockmobileTheme {
+        RegisterSaleIntroCard(onCreateSale = {})
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun RegisterSaleEmptyPreview() {
+private fun RegisterSaleDishesPreview() {
     RestockmobileTheme {
-        Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
-            RegisterSaleScreen(onBack = {})
-        }
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun RegisterSaleFormPreview() {
-    RestockmobileTheme {
-        val dateOption = SaleDateOption("Mar 03, 2023", "2023-03-03")
-        val timeOption = SaleTimeOption("12:30 pm")
-        val supplies = listOf(
-            SupplyOption(1, "Lemon", "Fresh whole lemons", 2.50),
-            SupplyOption(2, "Feta cheese", "Crumbled, 1 lb bag", 4.75),
-            SupplyOption(3, "Olive oil", "Extra virgin 500 ml", 7.80)
+        RegisterSaleDishesCard(
+            dishOptions = listOf(
+                DishOption(1, "Lomo Saltado", 20.50),
+                DishOption(2, "Arroz con Pollo", 15.50)
+            ),
+            supplyOptions = listOf(
+                SupplyOption(1, "Huevo", "1"),
+                SupplyOption(2, "Arroz", "250 g")
+            ),
+            selections = listOf(
+                DishSelection(DishOption(1, "Lomo Saltado", 20.50), 1, true),
+                DishSelection(DishOption(2, "Arroz con Pollo", 15.50), 2, true)
+            ),
+            onAddDish = {},
+            onAddSupply = {},
+            onToggleSelection = { _, _ -> },
+            onChangeQuantity = { _, _ -> },
+            onRemoveSelection = {},
+            onCancel = {},
+            onNext = {}
         )
+    }
+}
 
-        Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
-            SaleFormCard(
-                dateOptions = listOf(dateOption),
-                timeOptions = listOf(timeOption),
-                supplyOptions = supplies,
-                selectedDate = dateOption,
-                selectedTime = timeOption,
-                selections = supplies.take(2).associate { option ->
-                    option.id to SupplySelection(option, if (option.id == 1) 2 else 1)
-                },
-                showCreationHint = false,
-                onSelectDate = {},
-                onSelectTime = {},
-                onChangeQuantity = { _, _ -> }
-            )
-        }
+@Preview(showBackground = true)
+@Composable
+private fun RegisterSaleSuppliesPreview() {
+    RestockmobileTheme {
+        RegisterSaleSuppliesCard(
+            supplyOptions = listOf(
+                SupplyOption(1, "Huevo", "1"),
+                SupplyOption(2, "Arroz", "250 g")
+            ),
+            selections = listOf(
+                SupplySelection(SupplyOption(1, "Huevo", "1"), "1", true),
+                SupplySelection(SupplyOption(2, "Arroz", "250 g"), "250 g", true)
+            ),
+            onAddSupply = {},
+            onToggleSelection = { _, _ -> },
+            onChangeQuantity = { _, _ -> },
+            onRemoveSelection = {},
+            onBack = {},
+            onCancel = {},
+            onSave = {}
+        )
     }
 }
 
@@ -957,14 +1035,16 @@ private fun RegisterSaleFormPreview() {
 @Composable
 private fun RegisterSaleSuccessPreview() {
     RestockmobileTheme {
-        RegisterSaleSuccessContent(
-            selectedDate = SaleDateOption("Mar 03, 2023", "2023-03-03"),
-            selectedTime = SaleTimeOption("12:30 pm"),
-            selections = listOf(
-                SupplySelection(SupplyOption(1, "Lemon", "Fresh whole lemons", 2.50), 2),
-                SupplySelection(SupplyOption(2, "Feta cheese", "Crumbled, 1 lb bag", 4.75), 1)
+        RegisterSaleSuccessCard(
+            selectedDishes = listOf(
+                DishSelection(DishOption(1, "Lomo Saltado", 20.50), 1, true),
+                DishSelection(DishOption(2, "Arroz con Pollo", 15.50), 1, true)
             ),
-            onDismiss = {}
+            selectedSupplies = listOf(
+                SupplySelection(SupplyOption(1, "Huevo", "1"), "1", true),
+                SupplySelection(SupplyOption(2, "Arroz", "250 g"), "250 g", true)
+            ),
+            onClose = {}
         )
     }
 }


### PR DESCRIPTION
## Summary
- redesign the monitoring register sale experience with a multi-step flow for intro, dishes, supplies, and success states
- add reusable components for selection tables, action buttons, and previews that reflect the new UI layouts

## Testing
- ./gradlew --console=plain :app:assembleDebug *(fails: SDK location not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e55a1031b4832883c98e3ed2c956ee